### PR TITLE
Cleanup and zsh-autosuggestions enabled be default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,11 @@ Sets following useful aliases and ohmyzsh plugins. **You can add more or overwri
 * [web-search](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/web-search)    - search on the web from cli
 * [sudo](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/sudo)                - easily prefix your commands with sudo by pressing `esc` twice
 * [systemd](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/systemd)          - many useful aliases for systemd
-* https               - make httpie use https
 * myip - (wget -qO- https://wtfismyip.com/text)       - what's my ip: quickly find out external IP
 * cheat - (https://github.com/chubin/cheat.sh)        - cheatsheets in the terminal!
 * speedtest - (curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python3 -) run speedtest on the fly
 * dadjoke - (curl https://icanhazdadjoke.com)         - terminally sick jokes
-* dict - (curl "dict://dict.org/d:$1 $2 $3")          - dictionary definitions
 * ipgeo - (curl "http://api.db-ip.com/v2/free/$1")    - finds geo location from IP
-* corona - (curl "https://corona-stats.online/")      - shows corona virus spread live stats
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can also manually install Nerd Fonts of your choice.
 
 * All oh-my-zsh plugins are installed under ~/.config/ezsh/oh-my-zsh/plugin, Other tools (fzf,marker,todo) are installed in ~/.config/ezsh/
 
-* zsh-autosuggestions is not currently enabled due to a conflict with Marker. If you don't use Marker, enable it by adding `plugins+=(zsh-autosuggestions)` into your personal config file
+* If you use Marker, disable zsh-autosuggestions as it has a conflict with Marker (completion looks ugly). Add `plugins=(${plugins:#(zsh-autosuggestions)})` into your personal config file to remove it
 
 * The look of the shell can be very easily customised[https://github.com/bhilburn/powerlevel9k#prompt-customization] by overwriting POWERLEVEL10K settings
 in your personal config file under ~/.config/ezsh/zshrc/ . See example setup under example/personal_rc.zsh

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Sets following useful aliases and ohmyzsh plugins. **You can add more or overwri
 * l="ls -lah"         - just type "l" instead of "ls -lah"
 * alias k="k -h"	  - show human readable filesizes, in kb, mb etc
 * e="exit"
-* [x="extract"](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/extract)         - extract any compressed files
-* [z](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/z)   - quickly jump to most visited directories
-* [web-search](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/web-search)    - search on the web from cli
-* [sudo](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/sudo)                - easily prefix your commands with sudo by pressing `esc` twice
-* [systemd](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/systemd)          - many useful aliases for systemd
 * myip - (wget -qO- https://wtfismyip.com/text)       - what's my ip: quickly find out external IP
 * cheat - (https://github.com/chubin/cheat.sh)        - cheatsheets in the terminal!
 * speedtest - (curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python3 -) run speedtest on the fly
 * dadjoke - (curl https://icanhazdadjoke.com)         - terminally sick jokes
 * ipgeo - (curl "http://api.db-ip.com/v2/free/$1")    - finds geo location from IP
+* [x="extract"](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/extract)         - extract any compressed files
+* [z](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/z)   - quickly jump to most visited directories
+* [web-search](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/web-search)    - search on the web from cli
+* [sudo](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/sudo)                - easily prefix your commands with sudo by pressing `esc` twice
+* [systemd](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/systemd)          - many useful aliases for systemd
 
 ## Demo
 

--- a/example-config/personal_rc.zsh
+++ b/example-config/personal_rc.zsh
@@ -4,6 +4,9 @@
 # Additional OH-MY-ZSH plugins to enable
 plugins+=(lol httpie docker docker-compose pyenv pip)
 
+# Remove OH-MY-ZSH plugins from the default config
+plugins=(${plugins:#(zsh-autosuggestions|lol)})
+
 POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(virtualenv status command_execution_time background_jobs todo ram load rvm time)
 
 

--- a/example-config/personal_rc.zsh
+++ b/example-config/personal_rc.zsh
@@ -9,5 +9,4 @@ plugins=(${plugins:#(zsh-autosuggestions|lol)})
 
 POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(virtualenv status command_execution_time background_jobs todo ram load rvm time)
 
-
 # Custom Aliases, add your personal aliases here

--- a/ezshrc.zsh
+++ b/ezshrc.zsh
@@ -151,6 +151,9 @@ alias myip="wget -qO- https://wtfismyip.com/text"	# quickly show external ip add
 alias l="ls --hyperlink=auto -lAhrtF"    # show all except . .. , sort by recent, / at the end of folders, clickable
 alias e="exit"
 alias ip="ip --color=auto"
+## Install EZA to use this. The better ls command
+alias a='eza -la --git --colour-scale all -g --smart-group --icons always --hyperlink'  #the new ls
+alias aa='eza -la --git --colour-scale all -g --smart-group --icons always --hyperlink -s modified -r'#sort by new
 
 
 # CUSTOM FUNCTIONS

--- a/ezshrc.zsh
+++ b/ezshrc.zsh
@@ -75,7 +75,7 @@ POWERLEVEL9K_PROMPT_ON_NEWLINE=true
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(
     zsh-completions
-    # zsh-autosuggestions     # disable when using marker, otherwise enable
+    zsh-autosuggestions     # Disable if you are using Marker, otherwise enable
     zsh-syntax-highlighting
     history-substring-search
     screen
@@ -167,7 +167,6 @@ cheat() {
     fi
 }
 
-
 # Matrix screen saver! will run if you have installed "cmatrix"
 # TMOUT=900
 # TRAPALRM() { if command -v cmatrix &> /dev/null; then cmatrix -sb; fi }
@@ -178,17 +177,6 @@ speedtest() {
 
 dadjoke() {
     curl https://icanhazdadjoke.com
-}
-
-# Find dictionary definition
-dict() {
-    if [ "$3" ]; then
-        curl "dict://dict.org/d:$1 $2 $3"
-    elif [ "$2" ]; then
-        curl "dict://dict.org/d:$1 $2"
-    else
-        curl "dict://dict.org/d:$1"
-    fi
 }
 
 # Find geo info from IP


### PR DESCRIPTION
More people likely use zsh-autosuggestions than Marker. There's a slight conflict between them. Added instructions to remove any ohmyzsh plugins like zsh-autosuggestions if you need to.